### PR TITLE
feat: always initialize wallets

### DIFF
--- a/.changeset/breezy-pugs-jog.md
+++ b/.changeset/breezy-pugs-jog.md
@@ -1,0 +1,5 @@
+---
+"dot-connect": minor
+---
+
+Always initialize wallets on usage.

--- a/apps/docs/components/_WalletConnectionButton.vue
+++ b/apps/docs/components/_WalletConnectionButton.vue
@@ -1,8 +1,4 @@
 <script lang="ts" type="module">
-import {
-  initializeWallets,
-  aggregateWallets,
-} from "@reactive-dot/core/internal/actions.js";
 import { InjectedWalletProvider } from "@reactive-dot/core/wallets.js";
 import { LedgerWallet } from "@reactive-dot/wallet-ledger";
 import { MimirWalletProvider } from "@reactive-dot/wallet-mimir";
@@ -32,8 +28,6 @@ const wallets = [
 registerDotConnect({
   wallets,
 });
-
-void aggregateWallets(wallets).then(initializeWallets);
 
 export default {
   setup() {},

--- a/packages/dot-connect/src/stores.ts
+++ b/packages/dot-connect/src/stores.ts
@@ -5,16 +5,20 @@ import {
   aggregateWallets,
   getAccounts,
   getConnectedWallets,
+  initializeWallets,
 } from "@reactive-dot/core/internal/actions.js";
 import type { Wallet, WalletProvider } from "@reactive-dot/core/wallets.js";
 import { BehaviorSubject } from "rxjs";
-import { switchMap } from "rxjs/operators";
+import { switchMap, tap } from "rxjs/operators";
 
 export const walletsOrProviders$ = new BehaviorSubject<
   ReadonlyArray<Wallet | WalletProvider>
 >([]);
 
-export const wallets$ = walletsOrProviders$.pipe(switchMap(aggregateWallets));
+export const wallets$ = walletsOrProviders$.pipe(
+  switchMap(aggregateWallets),
+  tap((wallets) => initializeWallets(wallets)),
+);
 
 export const connectedWallets$ = getConnectedWallets(wallets$);
 


### PR DESCRIPTION
This will prevent unexpected behavior when the user forgets to initialize/mount ReactiveDOT correctly.